### PR TITLE
Build docker image containing curl

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git*
+curl/projects/
+curl/winbuild/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "curl"]
+	path = curl
+	url = https://github.com/curl/curl.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2019 Olliver Schinagl <oliver@schinagl.nl>
+#
+# SPDX-License-Identifier: MIT
+
+# For Alpine, latest is actually the latest stable
+# hadolint ignore=DL3007
+FROM registry.hub.docker.com/library/alpine:latest AS builder
+
+LABEL Maintainer="Olliver Schinagl <oliver@schinagl.nl>"
+
+# We want the latest stable version from the repo
+# hadolint ignore=DL3018
+RUN \
+    apk add --no-cache \
+       autoconf \
+       automake \
+       build-base \
+       curl-dev \
+       groff \
+       libtool \
+    && \
+    rm -rf "/var/cache/apk/"*
+
+COPY "./curl" "/curl"
+
+WORKDIR "/curl"
+
+RUN \
+    autoreconf -vif && \
+    ./configure \
+        --disable-ldap \
+        --enable-ipv6 \
+        --enable-unix-sockets \
+        --prefix=/usr \
+        --with-libssh2 \
+        --with-nghttp2 \
+        --with-pic \
+        --with-ssl \
+        --without-libidn \
+        --without-libidn2 \
+    && \
+    make && \
+    make DESTDIR="/alpine/" install
+
+# For Alpine, latest is actually the latest stable
+# hadolint ignore=DL3007
+FROM registry.hub.docker.com/library/alpine:latest
+
+RUN \
+    apk add --no-cache \
+        curl \
+    && \
+    rm -rf "/var/cache/apk/"* && \
+    for curlfile in $(apk info -L curl libcurl); do \
+        if [ -f "/${curlfile}" ]; then \
+            rm "/${curlfile:?}"; \
+        fi \
+    done
+
+COPY --from=builder "/alpine/usr/lib/libcurl.so.4.5.0" "/usr/lib/libcurl.so.4.5.0"
+COPY --from=builder "/alpine/usr/lib/libcurl.so.4" "/usr/lib/libcurl.so.4"
+COPY --from=builder "/alpine/usr/lib/libcurl.so" "/usr/lib/libcurl.so"
+COPY --from=builder "/alpine/usr/bin/curl" "/usr/bin/curl"
+
+COPY "./docker-entrypoint.sh" "/docker-entrypoint.sh"
+
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+curl/README.md

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+#
+# Copyright (C) 2019 Olliver Schinagl <oliver@schinagl.nl>
+#
+# SPDX-License-Identifier: MIT
+#
+# A beginning user should be able to docker run image bash (or sh) without
+# needing to learn about --entrypoint
+# https://github.com/docker-library/official-images#consistency
+
+set -eu
+
+# run command if it is not starting with a "-" and is an executable in PATH
+if [ "${#}" -gt "0" ] && \
+   [ "${1#-}" = "${1}" ] && \
+   command -v "${1}"; then
+    exec "${@}"
+else
+    # else default to run command with curl
+    exec curl "${@}"
+fi


### PR DESCRIPTION
What is left or rather needed, is for updates to be tagged in this repository. While I don't mind backwards tagging older versions of curl; we do need to setup a CI job on curl on every master commit, this repository reflects that; and that every tag gets pushed here as well.

Docker autobuild has already run for this repo: https://cloud.docker.com/repository/docker/olliver/curl/

Closes #1 

Signed-off-by: Olliver Schinagl <oliver@schinagl.nl>