### PR TITLE
Update 7.66.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ libstandaloneengine.a
 curl.tar.gz
 setup
 .DS_Store
+alpine/latest/curl
+bin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #***************************************************************************
 
 export LATEST_RELEASE_TAG=curl-7_66_0
-export LATEST_RELEASE_VERSION=7_66_0
+export LATEST_RELEASE_VERSION=7.66.0
 
 # set curl configure options
 export CONFIGURE_BUILD_OPTS=-"--enable-static --disable-shared --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --prefix=/usr"

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # set options
 #***************************************************************************
 
-export LATEST_RELEASE_TAG=curl-7_65_3
-export LATEST_RELEASE_VERSION=7_65_3
+export LATEST_RELEASE_TAG=curl-7_66_0
+export LATEST_RELEASE_VERSION=7_66_0
 
 # set curl configure options
 export CONFIGURE_BUILD_OPTS=-"--enable-static --disable-shared --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --prefix=/usr"

--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -60,7 +60,7 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.66.0 http://curl.haxx.se"
+LABEL docker.cmd="docker run -it curl/curl:${CURL_RELEASE_VERSION} http://curl.haxx.se"
 
 ###############################################################
 # dependencies

--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -60,7 +60,7 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.65.3 http://curl.haxx.se"
+LABEL docker.cmd="docker run -it curl/curl:7.66.0 http://curl.haxx.se"
 
 ###############################################################
 # dependencies

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -9,8 +9,10 @@ test:
 	docker run --rm -it curl/curl:${LATEST_RELEASE_VERSION} -S http://httpbin.org/get
 
 push-registry:
-	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.65.3
-	docker push curlimages/curl:7.65.3
+	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.66.0
+	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:latest
+	docker push curlimages/curl:7.66.0
+	docker push curlimages/curl:latest
 
 scan:
 	curl -s https://ci-tools.anchore.io/inline_scan-v0.3.3 | bash -s -- -p -r "curl/curl:${LATEST_RELEASE_VERSION}"

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -9,9 +9,9 @@ test:
 	docker run --rm -it curl/curl:${LATEST_RELEASE_VERSION} -S http://httpbin.org/get
 
 push-registry:
-	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.66.0
+	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:${LATEST_RELEASE_VERSION}
 	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:latest
-	docker push curlimages/curl:7.66.0
+	docker push curlimages/curl:${LATEST_RELEASE_VERSION}
 	docker push curlimages/curl:latest
 
 scan:

--- a/docs/dockerhub_docs.md
+++ b/docs/dockerhub_docs.md
@@ -1,6 +1,7 @@
 # Supported tags and respective Dockerfile links
 
-* [7.65.3](https://github.com/curl/curl-docker/blob/master/alpine/latest/Dockerfile)
+* [7.65.3](https://github.com/curl/curl-docker/blob/9dc2f169f0e8e57da8d54c01bd938275e049d098/alpine/latest/Dockerfile)
+* [7.66.0](https://github.com/curl/curl-docker/blob/master/alpine/latest/Dockerfile)
 
 # Quick reference
 * Where to get help: [website](https://curl.haxx.se/), [mailing lists](https://curl.haxx.se/mail/), [Everything Curl](https://curl.haxx.se/book.html)


### PR DESCRIPTION
Update for [curl 7.66.0 release](https://github.com/curl/curl/releases/tag/curl-7_66_0)

Tested locally (by removing `--squash` - see #9)

Not sure why there was so much `7_66_0` vs `7.66.0` (regression in #7 from @xquery ?) I tried to change those back to be parametrized from `LATEST_RELEASE_VERSION=7.66.0` which builds fine (undo last commit e0a30eb6a432708033e368c2cb910441012c8a44 if you disagree)

This also tags `:latest` as in #8 