### PR TITLE
fix #13 - add back scp and sftp support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ export LATEST_RELEASE_TAG=curl-7_67_0
 export LATEST_RELEASE_VERSION=7_67_0
 
 # set curl configure options
-export CONFIGURE_BUILD_OPTS=-"--enable-static --disable-shared --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --prefix=/usr"
+export CONFIGURE_BUILD_OPTS=" --enable-static --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2 --prefix=/usr/local"
 
 # set docker build options used when building docker images
-export DOCKER_BUILD_OPTS=--compress --squash
+export DOCKER_BUILD_OPTS=--no-cache --compress --squash
 
 # set docker build args used when building docker images
-export DOCKER_BUILD_ARGS =--build-arg CURL_CONFIGURE_OPTION=${configure_build_options} \
+export DOCKER_BUILD_ARGS =--build-arg CURL_CONFIGURE_OPTION=${CONFIGURE_BUILD_OPTS} \
     --build-arg CURL_RELEASE_TAG=${LATEST_RELEASE_TAG} \
     --build-arg CURL_RELEASE_VERSION=${LATEST_RELEASE_VERSION} \
     --build-arg CURL_GIT_REPO=https://github.com/curl/curl.git \

--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -24,11 +24,15 @@ ARG LABEL_DESC=curl
 # install deps and use latest curl release source
 RUN \
     apk add \
-       autoconf    \
-       automake    \
-       build-base  \
-       curl-dev    \
-       groff       \
+       libssh2-dev      \
+       libssh2          \
+       libssh2-static    \
+       autoconf     \
+       automake     \
+       build-base   \
+       groff        \
+       curl-dev     \
+       openssl      \
        libtool
 
 RUN mkdir /src
@@ -60,12 +64,12 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.65.3 http://curl.haxx.se"
+LABEL docker.cmd="docker run -it curl/curl:7.67.0 http://curl.haxx.se"
 
 ###############################################################
 # dependencies
 ###############################################################
-RUN apk add --no-cache nghttp2 ca-certificates
+RUN apk add --no-cache nghttp2 libssh2 ca-certificates curl
 
 ###############################################################
 # add non privileged curl user
@@ -73,16 +77,28 @@ RUN apk add --no-cache nghttp2 ca-certificates
 RUN addgroup -S curl_group && adduser -S curl_user -G curl_group
 
 ###############################################################
+# install curl ca bundle
+###############################################################
+RUN curl https://curl.haxx.se/ca/cacert.pem  -o cacert.pem
+ENV CURL_CA_BUNDLE="/cacert.pem"
+RUN apk del --no-cache curl ca-certificates
+
+###############################################################
 # install curl built from builder
 ###############################################################
 COPY --from=builder "/alpine/usr/local/lib/libcurl.so" "/usr/lib/libcurl.so"
-COPY --from=builder "/alpine/usr/local/lib/libcurl.so.4" "/usr/lib/libcurl.so.4"
+COPY --from=builder "/alpine/usr/local/lib/libcurl.so" "/usr/lib/libcurl.so"
+COPY --from=builder "/alpine/usr/local/lib/libcurl.so.4.6.0" "/usr/lib/libcurl.so.4"
 COPY --from=builder "/alpine/usr/local/bin/curl" "/usr/bin/curl"
 
 ###############################################################
-# copy and set entrypoint
+# set user
+###############################################################
+USER curl_user
+
+###############################################################
+# set entrypoint
 ###############################################################
 COPY "entrypoint.sh" "/entrypoint.sh"
-USER curl_user
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["curl"]


### PR DESCRIPTION
enables sftp

```
curl 7.67.0-DEV (x86_64-pc-linux-gnu) libcurl/7.67.0-DEV OpenSSL/1.1.1d zlib/1.2.11 libssh2/1.9.0 nghttp2/1.39.2
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher http https imap imaps pop3 pop3s rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: AsynchDNS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL TLS-SRP UnixSockets
```