### PR TITLE
bump 7.68.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # set options
 #***************************************************************************
 
-export LATEST_RELEASE_TAG=curl-7_67_0
-export LATEST_RELEASE_VERSION=7_67_0
+export LATEST_RELEASE_TAG=curl-7_68_0
+export LATEST_RELEASE_VERSION=7_68_0
 
 # set curl configure options
 export CONFIGURE_BUILD_OPTS=" --enable-static --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2 --prefix=/usr/local"

--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -64,7 +64,7 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.67.0 http://curl.haxx.se"
+LABEL docker.cmd="docker run -it curl/curl:7.68.0 http://curl.haxx.se"
 
 ###############################################################
 # dependencies

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -9,8 +9,8 @@ test:
 	docker run --rm -it curl/curl:${LATEST_RELEASE_VERSION} -S http://httpbin.org/get
 
 push-registry:
-	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.67.0
-	docker push curlimages/curl:7.67.0
+	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.68.0
+	docker push curlimages/curl:7.68.0
 	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:latest
 	docker push curlimages/curl:latest
 


### PR DESCRIPTION
bump build to 7.68.0

https://daniel.haxx.se/blog/2020/01/08/curl-7-68-0-with-etags-and-bearssl/
https://curl.haxx.se/changes.html