### PR TITLE
add multiarch (fixes #17), bump to 7.70.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,13 @@ language: minimal
 sudo: required
 dist: trusty
 
+env:
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+
 before_script:
-  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
   - sudo service docker restart
 
-script: make all
+script: make all multibuild
 
 branches:
     only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 before_script:
   - sudo service docker restart
 
-script: make all multibuild
+script: make all
 
 branches:
     only:

--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,16 @@
 # set options
 #***************************************************************************
 
-export LATEST_RELEASE_VERSION=7_69_1
+export LATEST_RELEASE_VERSION=7_70_0
 export LATEST_RELEASE_TAG=curl-${LATEST_RELEASE_VERSION}
+export DOCKER_CLI_EXPERIMENTAL=enabled
 
 # set curl configure options
 export CONFIGURE_BUILD_OPTS=" --enable-static --disable-ldap --enable-ipv6 --enable-unix-sockets --with-ssl --with-libssh2 --with-nghttp2=/usr \
 --prefix=/usr/local"
 
 # set docker build options used when building docker images
-export DOCKER_BUILD_OPTS=--no-cache --compress --squash
+export DOCKER_BUILD_OPTS=--no-cache --compress
 
 # set docker build args used when building docker images
 export DOCKER_BUILD_ARGS= --build-arg CURL_CONFIGURE_OPTION=${CONFIGURE_BUILD_OPTS} \
@@ -23,12 +24,21 @@ export DOCKER_BUILD_ARGS= --build-arg CURL_CONFIGURE_OPTION=${CONFIGURE_BUILD_OP
     --label se.haxx.curl.release_tag=${LATEST_RELEASE_TAG} \
     --label se.haxx.curl.description="network utility"
 
+export DOCKER_MULTI_ARCH=linux/arm,linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386
+
 #***************************************************************************
 # build docker images
 #***************************************************************************
 .build: .build-alpine
 .build-alpine:
 	cd alpine/latest;make build;
+
+#***************************************************************************
+# build and push multiarch docker images
+#***************************************************************************
+.multibuild: .multibuild-alpine
+.multibuild-alpine:
+	cd alpine/latest;make multibuild;
 
 #***************************************************************************
 # test docker images
@@ -81,6 +91,7 @@ export DOCKER_BUILD_ARGS= --build-arg CURL_CONFIGURE_OPTION=${CONFIGURE_BUILD_OP
 all: setup build test
 
 build: .build
+multibuild: .multibuild
 test: .test
 push: .push-registry
 scan: .scan

--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -64,7 +64,7 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.69.1 -s -L http://curl.haxx.se"
+LABEL docker.cmd="docker run -it curl/curl:7.70.0 -s -L http://curl.haxx.se"
 
 ###############################################################
 # dependencies

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:${LATEST_RELEASE_VERSION}" -f Dockerfile .
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curl/curl:${LATEST_RELEASE_VERSION}" -f Dockerfile .
 
 multibuild:
 	docker buildx build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:test_${LATEST_RELEASE_VERSION}" --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -2,7 +2,7 @@ build:
 	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curl/curl:${LATEST_RELEASE_VERSION}" -f Dockerfile .
 
 multibuild:
-	docker buildx build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:test_${LATEST_RELEASE_VERSION}" --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
+	docker buildx build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:7.70.0" --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
 
 lint:
 	docker run --rm --privileged -v ${PWD}:/root/ projectatomic/dockerfile-lint dockerfile_lint -p -f Dockerfile

--- a/alpine/latest/Makefile
+++ b/alpine/latest/Makefile
@@ -1,5 +1,8 @@
 build:
-	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curl/curl:${LATEST_RELEASE_VERSION}" -f Dockerfile .
+	docker build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:${LATEST_RELEASE_VERSION}" -f Dockerfile .
+
+multibuild:
+	docker buildx build ${DOCKER_BUILD_OPTS} ${DOCKER_BUILD_ARGS} -t "curlimages/curl:test_${LATEST_RELEASE_VERSION}" --platform=${DOCKER_MULTI_ARCH} -f Dockerfile . --push
 
 lint:
 	docker run --rm --privileged -v ${PWD}:/root/ projectatomic/dockerfile-lint dockerfile_lint -p -f Dockerfile
@@ -9,8 +12,8 @@ test:
 	docker run --rm -it curl/curl:${LATEST_RELEASE_VERSION} -S http://httpbin.org/get
 
 push-registry:
-	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.69.1
-	docker push curlimages/curl:7.69.1
+	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:7.70.0
+	docker push curlimages/curl:7.70.0
 	docker tag curl/curl:${LATEST_RELEASE_VERSION} curlimages/curl:latest
 	docker push curlimages/curl:latest
 


### PR DESCRIPTION
* use docker buildx option (eg. buildkit integration) to build multiarch ... initially we will support linux/arm,linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386
* bump to latest curl release (7_70_0)
* pin to alpine:3.11.5
* minor refactor and fixes #21
* narrow down some deps
* added some tests

