### PR TITLE
Remove redundant apk update

### DIFF
--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -22,11 +22,11 @@ ARG LABEL_DESC=curl
 # build curl
 ###############################################################
 # install deps and use latest curl release source
-RUN apk --update add libssh2 libssh2-dev libssh2-static \
-        autoconf automake build-base                    \
-        groff openssl curl-dev                          \
-        python3 python3-dev                             \
-        libtool curl stunnel perl                       \
+RUN apk add --no-cache libssh2 libssh2-dev libssh2-static \
+        autoconf automake build-base                      \
+        groff openssl curl-dev                            \
+        python3 python3-dev                               \
+        libtool curl stunnel perl                         \
         nghttp2
 
 RUN mkdir /src
@@ -72,10 +72,7 @@ LABEL docker.cmd="docker run -it curl/curl:7.74.0 -s -L http://curl.haxx.se"
 ###############################################################
 # dependencies
 ###############################################################
-RUN apk update --no-cache && \
-    apk upgrade --no-cache && \
-    apk add --update --no-cache libssh2 nghttp2-dev && \
-    rm -fr /var/cache/apk/*
+RUN apk add --no-cache libssh2 nghttp2-dev
 
 ###############################################################
 # add non privileged curl user

--- a/alpine/latest/scanDockerfile
+++ b/alpine/latest/scanDockerfile
@@ -10,15 +10,9 @@ FROM curl/curl:7_74_0
 
 USER root
 
-RUN apk update
-
-RUN \
-    echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-
-RUN apk update
-
-RUN apk add bash build-base clamav clamav-dev cvechecker unrar linux-headers
-RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing lynis
+RUN echo "@edge https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+RUN apk add --no-cache bash build-base clamav clamav-dev cvechecker unrar linux-headers
+RUN apk add --no-cache -X https://dl-cdn.alpinelinux.org/alpine/edge/testing lynis
 
 RUN curl https://sourceforge.net/projects/rkhunter/files/rkhunter/1.4.6/rkhunter-1.4.6.tar.gz/download -L -o rkhunter-1.4.6.tar.gz
 RUN gzip -d /rkhunter-1.4.6.tar.gz


### PR DESCRIPTION
Doing upgrades is [not recommend](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get), just use a newer base image.
`apk update` is redudant when using `--no-cache`.
Pulling packages from edge in a stable release is bad. This could result in conflicting binaries or libraries at any time. Maybe you just want to use `FROM alpine:edge`?