### PR TITLE
Fix image name + set latest image version

### DIFF
--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -67,7 +67,7 @@ ENV CURL_GIT_REPO ${CURL_GIT_REPO}
 LABEL Maintainer="James Fuller <jim.fuller@webcomposite.com>"
 LABEL Name="curl"
 LABEL Version="${LABEL_VERSION}"
-LABEL docker.cmd="docker run -it curl/curl:7.78.0 -s -L http://curl.se"
+LABEL docker.cmd="docker run -it curlimages/curl:7.79.1 -s -L https://curl.se"
 
 ###############################################################
 # dependencies


### PR DESCRIPTION
Previously:
```bash
docker run -it curl/curl:7.78.0 -s -L http://curl.se
# Unable to find image 'curl/curl:7.78.0' locally
# docker: Error response from daemon: pull access denied for curl/curl, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
# See 'docker run --help'.
```

Now:
```bash
docker run -it curlimages/curl:7.79.1 -s -L https://curl.se
# <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
# <html lang="en">
# <head>
# <title>curl</title>
# <meta name="viewport" content="width=device-width, initial-scale=1.0">
# <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
# ...
```