### PR TITLE
Add workdir to container

### DIFF
--- a/alpine/latest/Dockerfile
+++ b/alpine/latest/Dockerfile
@@ -105,6 +105,7 @@ RUN ln -s /usr/lib/libcurl.so.4 /usr/lib/libcurl.so
 # set user
 ###############################################################
 USER curl_user
+WORKDIR /home/curl_user
 
 ###############################################################
 # set entrypoint


### PR DESCRIPTION
This make default directory writable which makes it easier to use curl in multi-stage environment to fetch assets.